### PR TITLE
Fix watch URL generation and avoid sequential duplicate tracks

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -52,7 +52,7 @@ function extractVideoId(value) {
 }
 
 function toWatchUrl(videoId) {
-    return videoId ? `"https://www.youtube.com/watch?v=${videoId}`" : null;
+    return videoId ? `https://www.youtube.com/watch?v=${videoId}` : null;
 }
 
 chrome.runtime.onInstalled.addListener(async () => {

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -101,9 +101,15 @@ export async function addTrack(roomId, track, roomName) {
     const store = await readTrackStore();
     const tracks = store[roomId] ? [...store[roomId]] : [];
     const key = duplicateKey(track);
+    const lastTrack = tracks[tracks.length - 1];
+    const normaliseVideoId = (value) => String(value || "").trim().toLowerCase();
+    const newVideoId = normaliseVideoId(track.videoId);
+    const lastVideoId = normaliseVideoId(lastTrack?.videoId);
+    const sameVideoId = Boolean(lastTrack && newVideoId && lastVideoId && newVideoId === lastVideoId);
+    const isSameAsLast = Boolean(lastTrack && (sameVideoId || (!newVideoId && !lastVideoId && duplicateKey(lastTrack) === key)));
     const existingKeys = new Set(tracks.map(duplicateKey));
     let added = false;
-    if (!existingKeys.has(key)) {
+    if (!isSameAsLast && !existingKeys.has(key)) {
         tracks.push(track);
         store[roomId] = tracks;
         await writeTrackStore(store);


### PR DESCRIPTION
## Summary
- correct the generated YouTube watch URL returned by the background worker
- skip adding a track when it matches the most recently stored entry for a room

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf3f0b5f848327b79a4a233097b878